### PR TITLE
Update channels.csv

### DIFF
--- a/data/blocklist.csv
+++ b/data/blocklist.csv
@@ -804,7 +804,7 @@ WDPNDT7.us,https://github.zendesk.com/attachments/token/qCOIlhjNbuhARY64ffpnzv9E
 WNWTLD1.us,https://github.zendesk.com/attachments/token/qCOIlhjNbuhARY64ffpnzv9Ef/?name=2022-01-06-localnow.rtf
 WRJKLP3.us,https://github.zendesk.com/attachments/token/qCOIlhjNbuhARY64ffpnzv9Ef/?name=2022-01-06-localnow.rtf
 Xee.dk,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
-XTVN.kr,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
+XtvN.kr,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 ZonaDAZN.it,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 ZonaDAZN2.it,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md
 ZonaDAZN3.it,https://github.com/github/dmca/blob/master/2020/09/2020-09-16-dfl.md


### PR DESCRIPTION
id
ElSelloTV Madariaga

nombre
ElSelloTV Madariaga

alt_names
FALSE

owners
Sello Grupo Madariaga

country
AR

subdivision
AR-BA

city
General Madariaga

broadcast_area
s/AR-BA

languages
ESP

categories
general

is_nsfw
FALSE

launched
01/06/2018

closed
FALSE

replaced_by
FALSE

website
https://elsellotv.com.ar/

logo
https://elsellotv.com.ar/wp-content/uploads/2023/01/LogoTV23.png